### PR TITLE
Remove hardcoded reference to 'AnSwEr' blanks

### DIFF
--- a/OpenProblemLibrary/Rochester/setSeries6CompTests/ur_sr_6_10a.pg
+++ b/OpenProblemLibrary/Rochester/setSeries6CompTests/ur_sr_6_10a.pg
@@ -53,75 +53,54 @@ loadMacros(
 ################################################################
 
 sub custom_problem_grader {
-        my $rh_evaluated_answers = shift;
-        my $rh_problem_state = shift;
-        my %form_options = @_;
-        my %evaluated_answers = %{$rh_evaluated_answers};
-        #  The hash $rh_evaluated_answers typically contains: 
-        #      'answer1' => 34, 'answer2'=> 'Mozart', etc.
-       
-        # By default the  old problem state is simply passed back out again.
-        my %problem_state = %$rh_problem_state;
-        
-        
-        # %form_options might include
-        # The user login name 
-        # The permission level of the user
-        # The studentLogin name for this psvn.
-        # Whether the form is asking for a refresh or
-	#     is submitting a new answer.
-        
-        # initial setup of the answer
-        my      $total=0; 
-        my %problem_result = ( score => 0,
-                errors => '',
-                type => 'custom_problem_grader',
-                msg => 'To get full credit, all answers must be correct.  Having all but one correct is worth 50%.  Two or more incorrect answers gives a score of 0%.',
-                                                 );
+    my $evaluated_answers = shift;
+    my $problem_state = shift;
+    my %form_options = @_;
+
+    # initial setup of the answer
+    my $total = 0;
+    my $problem_result = {
+        score => 0,
+        errors => '',
+        type => 'custom_problem_grader',
+        msg => 'To get full credit, all answers must be correct.  Having all but one correct is worth 50%.  Two or more incorrect answers gives a score of 0%.',
+    };
 
     # Return unless answers have been submitted
-    unless ($form_options{answers_submitted} == 1) {
-    
-    # Since this code is in a .pg file we must use double tildes 
-    # instead of Perl's backslash on the next line.
-                return(~~%problem_result,~~%problem_state);
-        }
-        # Answers have been submitted -- process them.
-        
-	########################################################
-	# Here's where we compute the score.  The variable     #
-	# $numright is the number of correct answers.          #
-	########################################################
+    return($problem_result, $problem_state) unless ($form_options{answers_submitted} == 1);
 
-        my      $numright=0;
+    # Answers have been submitted -- process them.
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0006'}->{score});
+    ########################################################
+    # Here's where we compute the score.  The variable     #
+    # $numright is the number of correct answers.          #
+    ########################################################
+    my $numright=0;
 
-	if ($numright == 6) {
-		$total = 1;
-	} elsif ($numright == 5) {
-		$total = 0.5;
-	} else {
-		$total = 0;
-	}
+    foreach my $key (keys %$evaluated_answers) {
+        # summing the scores is identical to checking each one is correct
+        $numright += $evaluated_answers->{$key}{score};
+    }
 
-        $problem_result{score} = $total; 
-        # increase recorded score if the current score is greater.
-        $problem_state{recorded_score} = $problem_result{score} if $problem_result{score} > $problem_state{recorded_score};
+    if ($numright == 6) {
+        $problem_result->{msg} = 'This attempt scored 100%. Nice work.';
+	$total = 1;
+    } elsif ($numright == 5) {
+        $problem_result->{msg} = 'This attempt scored 50%. You must answer each part correctly for full credit.';
+	$total = 0.5;
+    } else {
+        # the default message will suffice
+	$total = 0;
+    }
 
-        
+    $problem_result->{score} = $total;
+
+    # increase recorded score if the current score is greater.
+    $problem_state->{recorded_score} = $problem_result{score} if $problem_result{score} > $problem_state{recorded_score};
+
     $problem_state{num_of_correct_ans}++ if $total == 1;
-        $problem_state{num_of_incorrect_ans}++ if $total < 1 ;
-        
-        # Since this code is in a .pg file we must use double tildes 
-    # instead of Perl's backslash on the next line.
-        (~~%problem_result, ~~%problem_state);
-
+    $problem_state{num_of_incorrect_ans}++ if $total < 1;
+    return ($problem_result, $problem_state);
 }
 
 ################################################################


### PR DESCRIPTION
`Library/Rochester/setSeries6CompTests/ur_sr_6_10a.pg` used a custom answer _grader_ that relied on hard-coded names for each answer blank. This grader fails when used in any context that modifies the id of answer blanks (e.g. LTI or gateway assignments) as pointed out by @ionparticle in openwebwork/webwork-open-problem-library#927.

Now we instead loop through the available answer blanks as provided in the `evaluated_answers` hash instead, so that changes in the field ids will no longer make any difference in scoring.